### PR TITLE
Linter error-count getting 🚀

### DIFF
--- a/src/linterChecks/index.js
+++ b/src/linterChecks/index.js
@@ -1,15 +1,14 @@
-const shell = require('shelljs');
 const { eslintMetrics, eslintTechConfig } = require('./constants');
+const { getLinterErrorCount } = require('./utils');
 
 module.exports = (testPath, tech) => {
   const eslintResponse = [];
   const eslintConfig = require(`../../${testPath}/.eslintrc.js`);
-  const child = shell.exec(`npm run lint --prefix ${testPath}`);
 
   eslintResponse.push({
     metric: eslintMetrics.ESLINT_ERRORS,
     description: 'Errores de eslint',
-    value: (child.stdout.toString().match(/\berror\b/g) || []).length
+    value: getLinterErrorCount(testPath)
   });
 
   eslintResponse.push({

--- a/src/linterChecks/utils.js
+++ b/src/linterChecks/utils.js
@@ -1,0 +1,8 @@
+const shell = require('shelljs');
+const { fetchJSON } = require('../utils');
+
+module.exports.getLinterErrorCount = testPath => {
+  shell.exec(`npm run lint --prefix ${testPath} -- --format json -o report.json`);
+  const linterReport = fetchJSON(`${testPath}/report.json`);
+  return linterReport.reduce((errorCount, current) => errorCount + current.errorCount, 0);
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 const percentage = 100;
 
 const removeComments = match => match.line.filter(line => line.substring(0, 2) !== '//');
@@ -9,3 +11,5 @@ exports.analyzeMatches = matches => Object.keys(matches).filter(key => removeCom
 exports.calculatePercentage = (results, total) =>
   // eslint-disable-next-line prettier/prettier
   this.analyzeMatches(results).length / total * percentage;
+
+exports.fetchJSON = path => JSON.parse(fs.readFileSync(path));

--- a/src/utils/linterFormatter.js
+++ b/src/utils/linterFormatter.js
@@ -1,5 +1,0 @@
-module.exports = results => {
-  const errorCount = results.reduce((_errorCount, report) => _errorCount + report.errorCount, 0);
-
-  return `Your code have ${errorCount} ${errorCount === 1 ? 'error' : 'errors'}`;
-};

--- a/src/utils/linterFormatter.js
+++ b/src/utils/linterFormatter.js
@@ -1,0 +1,5 @@
+module.exports = results => {
+  const errorCount = results.reduce((_errorCount, report) => _errorCount + report.errorCount, 0);
+
+  return `Your code have ${errorCount} ${errorCount === 1 ? 'error' : 'errors'}`;
+};


### PR DESCRIPTION
## Summary

- Updated error-getting strategy using json format in aims to get error count from that generated report.
- I have found that in several wolox projects the lint script have `-f json -o report.js` as output configuration. In this PR the `report.json` gonna be generated regardless that configuration is setted for that project. As Improve we can remove that file after report is generated, but maybe some edge cases should be considered. For now, create that report when doesn't exists it's not a problem.